### PR TITLE
Split and rearranged MPI send and recv

### DIFF
--- a/GeosCore/fullchem_mod.F90
+++ b/GeosCore/fullchem_mod.F90
@@ -1155,39 +1155,39 @@ CONTAINS
 #endif
       ! Pass the actual data
       CALL MPI_Isend( &
-          C_recv(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * NSPEC, MPI_DOUBLE_PRECISION, &
-          reassignment_data(interval)%next_PET, 4, &
-          Input_Opt%mpiComm, request, RC)
-      CALL MPI_Recv( &
           C_send(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * NSPEC, MPI_DOUBLE_PRECISION, &
-          reassignment_data(interval)%prev_PET, 4, &
+          reassignment_data(interval)%prev_PET, 0, &
+          Input_Opt%mpiComm, request, RC)
+      CALL MPI_Recv( &
+          C_recv(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * NSPEC, MPI_DOUBLE_PRECISION, &
+          reassignment_data(interval)%next_PET, 0, &
           Input_Opt%mpiComm, MPI_STATUS_IGNORE, RC)
 
       CALL MPI_Isend( &
-          RCONST_recv(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * NREACT, MPI_DOUBLE_PRECISION, &
-          reassignment_data(interval)%next_PET, 5, &
-          Input_Opt%mpiComm, request, RC)
-      CALL MPI_Recv( &
           RCONST_send(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * NREACT, MPI_DOUBLE_PRECISION, &
-          reassignment_data(interval)%prev_PET, 5, &
+          reassignment_data(interval)%prev_PET, 1, &
+          Input_Opt%mpiComm, request, RC)
+      CALL MPI_Recv( &
+          RCONST_recv(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * NREACT, MPI_DOUBLE_PRECISION, &
+          reassignment_data(interval)%next_PET, 1, &
           Input_Opt%mpiComm, MPI_STATUS_IGNORE, RC)
 
       CALL MPI_Isend( &
-          I_recv(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * 20, MPI_INTEGER, &
-          reassignment_data(interval)%next_PET, 6, &
-          Input_Opt%mpiComm, request, RC)
-      CALL MPI_Recv( &
           I_send(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * 20, MPI_INTEGER, &
-          reassignment_data(interval)%prev_PET, 6, &
+          reassignment_data(interval)%prev_PET, 2, &
+          Input_Opt%mpiComm, request, RC)
+      CALL MPI_Recv( &
+          I_recv(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * 20, MPI_INTEGER, &
+          reassignment_data(interval)%next_PET, 2, &
           Input_Opt%mpiComm, MPI_STATUS_IGNORE, RC)
 
       CALL MPI_Isend( &
-          R_recv(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * 20, MPI_DOUBLE_PRECISION, &
-          reassignment_data(interval)%next_PET, 7, &
+          R_send(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * 20, MPI_DOUBLE_PRECISION, &
+          reassignment_data(interval)%prev_PET, 3, &
           Input_Opt%mpiComm, request, RC)
       CALL MPI_Recv( &
-          R_send(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * 20, MPI_DOUBLE_PRECISION, &
-          reassignment_data(interval)%prev_PET, 7, &
+          R_recv(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * 20, MPI_DOUBLE_PRECISION, &
+          reassignment_data(interval)%next_PET, 3, &
           Input_Opt%mpiComm, MPI_STATUS_IGNORE, RC)
 #ifdef HIRES_TIMER
         TimerEnd = rdtsc()
@@ -1449,39 +1449,39 @@ CONTAINS
 #endif
       ! Pass the actual data
       CALL MPI_Isend( &
-          C_send(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * NSPEC, MPI_DOUBLE_PRECISION, &
-          reassignment_data(interval)%prev_PET, 0, &
-          Input_Opt%mpiComm, request, RC)
-      CALL MPI_Recv( &
           C_recv(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * NSPEC, MPI_DOUBLE_PRECISION, &
-          reassignment_data(interval)%next_PET, 0, &
+          reassignment_data(interval)%next_PET, 4, &
+          Input_Opt%mpiComm, request, RC)
+      CALL MPI_Recv( &
+          C_send(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * NSPEC, MPI_DOUBLE_PRECISION, &
+          reassignment_data(interval)%prev_PET, 4, &
           Input_Opt%mpiComm, MPI_STATUS_IGNORE, RC)
 
       CALL MPI_Isend( &
-          RCONST_send(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * NREACT, MPI_DOUBLE_PRECISION, &
-          reassignment_data(interval)%prev_PET, 1, &
-          Input_Opt%mpiComm, request, RC)
-      CALL MPI_Recv( &
           RCONST_recv(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * NREACT, MPI_DOUBLE_PRECISION, &
-          reassignment_data(interval)%next_PET, 1, &
+          reassignment_data(interval)%next_PET, 5, &
+          Input_Opt%mpiComm, request, RC)
+      CALL MPI_Recv( &
+          RCONST_send(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * NREACT, MPI_DOUBLE_PRECISION, &
+          reassignment_data(interval)%prev_PET, 5, &
           Input_Opt%mpiComm, MPI_STATUS_IGNORE, RC)
 
       CALL MPI_Isend( &
-          I_send(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * 20, MPI_INTEGER, &
-          reassignment_data(interval)%prev_PET, 2, &
-          Input_Opt%mpiComm, request, RC)
-      CALL MPI_Recv( &
           I_recv(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * 20, MPI_INTEGER, &
-          reassignment_data(interval)%next_PET, 2, &
+          reassignment_data(interval)%next_PET, 6, &
+          Input_Opt%mpiComm, request, RC)
+      CALL MPI_Recv( &
+          I_send(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * 20, MPI_INTEGER, &
+          reassignment_data(interval)%prev_PET, 6, &
           Input_Opt%mpiComm, MPI_STATUS_IGNORE, RC)
 
       CALL MPI_Isend( &
-          R_send(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * 20, MPI_DOUBLE_PRECISION, &
-          reassignment_data(interval)%prev_PET, 3, &
+          R_recv(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * 20, MPI_DOUBLE_PRECISION, &
+          reassignment_data(interval)%next_PET, 7, &
           Input_Opt%mpiComm, request, RC)
       CALL MPI_Recv( &
-          R_recv(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * 20, MPI_DOUBLE_PRECISION, &
-          reassignment_data(interval)%next_PET, 3, &
+          R_send(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * 20, MPI_DOUBLE_PRECISION, &
+          reassignment_data(interval)%prev_PET, 7, &
           Input_Opt%mpiComm, MPI_STATUS_IGNORE, RC)
 #ifdef HIRES_TIMER
         TimerEnd = rdtsc()

--- a/GeosCore/fullchem_mod.F90
+++ b/GeosCore/fullchem_mod.F90
@@ -11,7 +11,7 @@
 !\\
 ! !INTERFACE:
 !
-#define HIRES_TIMER
+! #define HIRES_TIMER
 MODULE FullChem_Mod
 !
 ! !USES:

--- a/GeosCore/fullchem_mod.F90
+++ b/GeosCore/fullchem_mod.F90
@@ -1156,19 +1156,19 @@ CONTAINS
       ! Pass the actual data
       CALL MPI_Isend( &
           C_send(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * NSPEC, MPI_DOUBLE_PRECISION, &
-          reassignment_data(interval)%prev_PET, 0, &
+          reassignment_data(interval)%next_PET, 0, &
           Input_Opt%mpiComm, request, RC)
       CALL MPI_Isend( &
           RCONST_send(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * NREACT, MPI_DOUBLE_PRECISION, &
-          reassignment_data(interval)%prev_PET, 1, &
+          reassignment_data(interval)%next_PET, 1, &
           Input_Opt%mpiComm, request, RC)
       CALL MPI_Isend( &
           I_send(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * 20, MPI_INTEGER, &
-          reassignment_data(interval)%prev_PET, 2, &
+          reassignment_data(interval)%next_PET, 2, &
           Input_Opt%mpiComm, request, RC)
       CALL MPI_Isend( &
           R_send(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * 20, MPI_DOUBLE_PRECISION, &
-          reassignment_data(interval)%prev_PET, 3, &
+          reassignment_data(interval)%next_PET, 3, &
           Input_Opt%mpiComm, request, RC)
 #ifdef HIRES_TIMER
         TimerEnd = rdtsc()
@@ -1179,19 +1179,19 @@ CONTAINS
 #endif
       CALL MPI_Recv( &
           C_recv(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * NSPEC, MPI_DOUBLE_PRECISION, &
-          reassignment_data(interval)%next_PET, 0, &
+          reassignment_data(interval)%prev_PET, 0, &
           Input_Opt%mpiComm, MPI_STATUS_IGNORE, RC)
       CALL MPI_Recv( &
           RCONST_recv(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * NREACT, MPI_DOUBLE_PRECISION, &
-          reassignment_data(interval)%next_PET, 1, &
+          reassignment_data(interval)%prev_PET, 1, &
           Input_Opt%mpiComm, MPI_STATUS_IGNORE, RC)
       CALL MPI_Recv( &
           I_recv(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * 20, MPI_INTEGER, &
-          reassignment_data(interval)%next_PET, 2, &
+          reassignment_data(interval)%prev_PET, 2, &
           Input_Opt%mpiComm, MPI_STATUS_IGNORE, RC)
       CALL MPI_Recv( &
           R_recv(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * 20, MPI_DOUBLE_PRECISION, &
-          reassignment_data(interval)%next_PET, 3, &
+          reassignment_data(interval)%prev_PET, 3, &
           Input_Opt%mpiComm, MPI_STATUS_IGNORE, RC)
 #ifdef HIRES_TIMER
         TimerEnd = rdtsc()
@@ -1454,20 +1454,20 @@ CONTAINS
       ! Pass the actual data
       CALL MPI_Isend( &
           C_recv(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * NSPEC, MPI_DOUBLE_PRECISION, &
-          reassignment_data(interval)%next_PET, 4, &
+          reassignment_data(interval)%prev_PET, 4, &
           Input_Opt%mpiComm, request, RC)
       CALL MPI_Isend( &
           RCONST_recv(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * NREACT, MPI_DOUBLE_PRECISION, &
-          reassignment_data(interval)%next_PET, 5, &
+          reassignment_data(interval)%prev_PET, 5, &
           Input_Opt%mpiComm, request, RC)
       CALL MPI_Isend( &
           I_recv(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * 20, MPI_INTEGER, &
-          reassignment_data(interval)%next_PET, 6, &
+          reassignment_data(interval)%prev_PET, 6, &
           Input_Opt%mpiComm, request, RC)
 
       CALL MPI_Isend( &
           R_recv(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * 20, MPI_DOUBLE_PRECISION, &
-          reassignment_data(interval)%next_PET, 7, &
+          reassignment_data(interval)%prev_PET, 7, &
           Input_Opt%mpiComm, request, RC)
 #ifdef HIRES_TIMER
         TimerEnd = rdtsc()
@@ -1478,20 +1478,20 @@ CONTAINS
 #endif
       CALL MPI_Recv( &
           C_send(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * NSPEC, MPI_DOUBLE_PRECISION, &
-          reassignment_data(interval)%prev_PET, 4, &
+          reassignment_data(interval)%next_PET, 4, &
           Input_Opt%mpiComm, MPI_STATUS_IGNORE, RC)
       CALL MPI_Recv( &
           RCONST_send(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * NREACT, MPI_DOUBLE_PRECISION, &
-          reassignment_data(interval)%prev_PET, 5, &
+          reassignment_data(interval)%next_PET, 5, &
           Input_Opt%mpiComm, MPI_STATUS_IGNORE, RC)
 
       CALL MPI_Recv( &
           I_send(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * 20, MPI_INTEGER, &
-          reassignment_data(interval)%prev_PET, 6, &
+          reassignment_data(interval)%next_PET, 6, &
           Input_Opt%mpiComm, MPI_STATUS_IGNORE, RC)
       CALL MPI_Recv( &
           R_send(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * 20, MPI_DOUBLE_PRECISION, &
-          reassignment_data(interval)%prev_PET, 7, &
+          reassignment_data(interval)%next_PET, 7, &
           Input_Opt%mpiComm, MPI_STATUS_IGNORE, RC)
 #ifdef HIRES_TIMER
         TimerEnd = rdtsc()

--- a/GeosCore/fullchem_mod.F90
+++ b/GeosCore/fullchem_mod.F90
@@ -1158,33 +1158,37 @@ CONTAINS
           C_send(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * NSPEC, MPI_DOUBLE_PRECISION, &
           reassignment_data(interval)%prev_PET, 0, &
           Input_Opt%mpiComm, request, RC)
-      CALL MPI_Recv( &
-          C_recv(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * NSPEC, MPI_DOUBLE_PRECISION, &
-          reassignment_data(interval)%next_PET, 0, &
-          Input_Opt%mpiComm, MPI_STATUS_IGNORE, RC)
-
       CALL MPI_Isend( &
           RCONST_send(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * NREACT, MPI_DOUBLE_PRECISION, &
           reassignment_data(interval)%prev_PET, 1, &
           Input_Opt%mpiComm, request, RC)
-      CALL MPI_Recv( &
-          RCONST_recv(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * NREACT, MPI_DOUBLE_PRECISION, &
-          reassignment_data(interval)%next_PET, 1, &
-          Input_Opt%mpiComm, MPI_STATUS_IGNORE, RC)
-
       CALL MPI_Isend( &
           I_send(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * 20, MPI_INTEGER, &
           reassignment_data(interval)%prev_PET, 2, &
           Input_Opt%mpiComm, request, RC)
-      CALL MPI_Recv( &
-          I_recv(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * 20, MPI_INTEGER, &
-          reassignment_data(interval)%next_PET, 2, &
-          Input_Opt%mpiComm, MPI_STATUS_IGNORE, RC)
-
       CALL MPI_Isend( &
           R_send(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * 20, MPI_DOUBLE_PRECISION, &
           reassignment_data(interval)%prev_PET, 3, &
           Input_Opt%mpiComm, request, RC)
+#ifdef HIRES_TIMER
+        TimerEnd = rdtsc()
+        ! Write both times to timer log file
+        WRITE(unit_number, *) Interval, 'ForwardIsend', TimerStart, TimerEnd
+        
+        TimerStart = rdtsc()
+#endif
+      CALL MPI_Recv( &
+          C_recv(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * NSPEC, MPI_DOUBLE_PRECISION, &
+          reassignment_data(interval)%next_PET, 0, &
+          Input_Opt%mpiComm, MPI_STATUS_IGNORE, RC)
+      CALL MPI_Recv( &
+          RCONST_recv(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * NREACT, MPI_DOUBLE_PRECISION, &
+          reassignment_data(interval)%next_PET, 1, &
+          Input_Opt%mpiComm, MPI_STATUS_IGNORE, RC)
+      CALL MPI_Recv( &
+          I_recv(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * 20, MPI_INTEGER, &
+          reassignment_data(interval)%next_PET, 2, &
+          Input_Opt%mpiComm, MPI_STATUS_IGNORE, RC)
       CALL MPI_Recv( &
           R_recv(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * 20, MPI_DOUBLE_PRECISION, &
           reassignment_data(interval)%next_PET, 3, &
@@ -1192,7 +1196,7 @@ CONTAINS
 #ifdef HIRES_TIMER
         TimerEnd = rdtsc()
         ! Write both times to timer log file
-        WRITE(unit_number, *) Interval, 'ForwardMPI', TimerStart, TimerEnd
+        WRITE(unit_number, *) Interval, 'ForwardRecv', TimerStart, TimerEnd
         
         TimerStart = rdtsc()
 #endif
@@ -1452,33 +1456,39 @@ CONTAINS
           C_recv(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * NSPEC, MPI_DOUBLE_PRECISION, &
           reassignment_data(interval)%next_PET, 4, &
           Input_Opt%mpiComm, request, RC)
-      CALL MPI_Recv( &
-          C_send(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * NSPEC, MPI_DOUBLE_PRECISION, &
-          reassignment_data(interval)%prev_PET, 4, &
-          Input_Opt%mpiComm, MPI_STATUS_IGNORE, RC)
-
       CALL MPI_Isend( &
           RCONST_recv(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * NREACT, MPI_DOUBLE_PRECISION, &
           reassignment_data(interval)%next_PET, 5, &
           Input_Opt%mpiComm, request, RC)
-      CALL MPI_Recv( &
-          RCONST_send(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * NREACT, MPI_DOUBLE_PRECISION, &
-          reassignment_data(interval)%prev_PET, 5, &
-          Input_Opt%mpiComm, MPI_STATUS_IGNORE, RC)
-
       CALL MPI_Isend( &
           I_recv(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * 20, MPI_INTEGER, &
           reassignment_data(interval)%next_PET, 6, &
           Input_Opt%mpiComm, request, RC)
-      CALL MPI_Recv( &
-          I_send(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * 20, MPI_INTEGER, &
-          reassignment_data(interval)%prev_PET, 6, &
-          Input_Opt%mpiComm, MPI_STATUS_IGNORE, RC)
 
       CALL MPI_Isend( &
           R_recv(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * 20, MPI_DOUBLE_PRECISION, &
           reassignment_data(interval)%next_PET, 7, &
           Input_Opt%mpiComm, request, RC)
+#ifdef HIRES_TIMER
+        TimerEnd = rdtsc()
+        ! Write both times to timer log file
+        WRITE(unit_number, *) Interval, 'ReverseIsend', TimerStart, TimerEnd
+        
+        TimerStart = rdtsc()
+#endif
+      CALL MPI_Recv( &
+          C_send(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * NSPEC, MPI_DOUBLE_PRECISION, &
+          reassignment_data(interval)%prev_PET, 4, &
+          Input_Opt%mpiComm, MPI_STATUS_IGNORE, RC)
+      CALL MPI_Recv( &
+          RCONST_send(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * NREACT, MPI_DOUBLE_PRECISION, &
+          reassignment_data(interval)%prev_PET, 5, &
+          Input_Opt%mpiComm, MPI_STATUS_IGNORE, RC)
+
+      CALL MPI_Recv( &
+          I_send(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * 20, MPI_INTEGER, &
+          reassignment_data(interval)%prev_PET, 6, &
+          Input_Opt%mpiComm, MPI_STATUS_IGNORE, RC)
       CALL MPI_Recv( &
           R_send(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * 20, MPI_DOUBLE_PRECISION, &
           reassignment_data(interval)%prev_PET, 7, &
@@ -1486,7 +1496,7 @@ CONTAINS
 #ifdef HIRES_TIMER
         TimerEnd = rdtsc()
         ! Write both times to timer log file
-        WRITE(unit_number, *) Interval, 'ReverseMPI', TimerStart, TimerEnd
+        WRITE(unit_number, *) Interval, 'ReverseRecv', TimerStart, TimerEnd
         
         TimerStart = rdtsc()
 #endif

--- a/GeosCore/fullchem_mod.F90
+++ b/GeosCore/fullchem_mod.F90
@@ -1153,50 +1153,38 @@ CONTAINS
         
         TimerStart = rdtsc()
 #endif
-        ! Pass the actual data using non-blocking sends and blocking receives
-        CALL MPI_Isend( &
-            C_send(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * NSPEC, MPI_DOUBLE_PRECISION, &
-            reassignment_data(interval)%next_PET, 0, &
-            Input_Opt%mpiComm, request, RC)
-        CALL MPI_Isend( &
-            RCONST_send(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * NREACT, MPI_DOUBLE_PRECISION, &
-            reassignment_data(interval)%next_PET, 1, &
-            Input_Opt%mpiComm, request, RC)
-        CALL MPI_Isend( &
-            I_send(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * 20, MPI_INTEGER, &
-            reassignment_data(interval)%next_PET, 2, &
-            Input_Opt%mpiComm, request, RC)
-        CALL MPI_Isend( &
-            R_send(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * 20, MPI_DOUBLE_PRECISION, &
-            reassignment_data(interval)%next_PET, 3, &
-            Input_Opt%mpiComm, request, RC)
-#ifdef HIRES_TIMER
-        TimerEnd = rdtsc()
-        ! Write both times to timer log file
-        WRITE(unit_number, *) Interval, 'ForwardISend', TimerStart, TimerEnd
-        
-        TimerStart = rdtsc()
-#endif
-        CALL MPI_Recv( &
+        ! Pass the actual data
+        CALL MPI_Sendrecv( &
             C_recv(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * NSPEC, MPI_DOUBLE_PRECISION, &
-            reassignment_data(interval)%prev_PET, 0, &
+            reassignment_data(interval)%next_PET, 4, &
+            C_send(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * NSPEC, MPI_DOUBLE_PRECISION, &
+            reassignment_data(interval)%prev_PET, 4, &
             Input_Opt%mpiComm, MPI_STATUS_IGNORE, RC)
-        CALL MPI_Recv( &
+
+        CALL MPI_Sendrecv( &
             RCONST_recv(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * NREACT, MPI_DOUBLE_PRECISION, &
-            reassignment_data(interval)%prev_PET, 1, &
+            reassignment_data(interval)%next_PET, 5, &
+            RCONST_send(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * NREACT, MPI_DOUBLE_PRECISION, &
+            reassignment_data(interval)%prev_PET, 5, &
             Input_Opt%mpiComm, MPI_STATUS_IGNORE, RC)
-        CALL MPI_Recv( &
+
+        CALL MPI_Sendrecv( &
             I_recv(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * 20, MPI_INTEGER, &
-            reassignment_data(interval)%prev_PET, 2, &
+            reassignment_data(interval)%next_PET, 6, &
+            I_send(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * 20, MPI_INTEGER, &
+            reassignment_data(interval)%prev_PET, 6, &
             Input_Opt%mpiComm, MPI_STATUS_IGNORE, RC)
-        CALL MPI_Recv( &
+
+        CALL MPI_Sendrecv( &
             R_recv(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * 20, MPI_DOUBLE_PRECISION, &
-            reassignment_data(interval)%prev_PET, 3, &
+            reassignment_data(interval)%next_PET, 7, &
+            R_send(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * 20, MPI_DOUBLE_PRECISION, &
+            reassignment_data(interval)%prev_PET, 7, &
             Input_Opt%mpiComm, MPI_STATUS_IGNORE, RC)
 #ifdef HIRES_TIMER
         TimerEnd = rdtsc()
         ! Write both times to timer log file
-        WRITE(unit_number, *) Interval, 'ForwardRecv', TimerStart, TimerEnd
+        WRITE(unit_number, *) Interval, 'ForwardMPI', TimerStart, TimerEnd
         
         TimerStart = rdtsc()
 #endif
@@ -1451,50 +1439,38 @@ CONTAINS
 
         TimerStart = rdtsc()
 #endif
-        ! Pass the actual data using non-blocking sends and blocking receives
-        CALL MPI_Isend( &
-            C_recv(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * NSPEC, MPI_DOUBLE_PRECISION, &
-            reassignment_data(interval)%next_PET, 4, &
-            Input_Opt%mpiComm, request, RC)
-        CALL MPI_Isend( &
-            RCONST_recv(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * NREACT, MPI_DOUBLE_PRECISION, &
-            reassignment_data(interval)%next_PET, 5, &
-            Input_Opt%mpiComm, request, RC)
-        CALL MPI_Isend( &
-            I_recv(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * 20, MPI_INTEGER, &
-            reassignment_data(interval)%next_PET, 6, &
-            Input_Opt%mpiComm, request, RC)
-        CALL MPI_Isend( &
-            R_recv(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * 20, MPI_DOUBLE_PRECISION, &
-            reassignment_data(interval)%next_PET, 7, &
-            Input_Opt%mpiComm, request, RC)
-#ifdef HIRES_TIMER
-        TimerEnd = rdtsc()
-        ! Write both times to timer log file
-        WRITE(unit_number, *) Interval, 'ReverseIsend', TimerStart, TimerEnd
-        
-        TimerStart = rdtsc()
-#endif
-        CALL MPI_Recv( &
+        ! Pass the actual data
+        CALL MPI_Sendrecv( &
             C_send(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * NSPEC, MPI_DOUBLE_PRECISION, &
-            reassignment_data(interval)%prev_PET, 4, &
+            reassignment_data(interval)%prev_PET, 0, &
+            C_recv(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * NSPEC, MPI_DOUBLE_PRECISION, &
+            reassignment_data(interval)%next_PET, 0, &
             Input_Opt%mpiComm, MPI_STATUS_IGNORE, RC)
-        CALL MPI_Recv( &
+
+        CALL MPI_Sendrecv( &
             RCONST_send(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * NREACT, MPI_DOUBLE_PRECISION, &
-            reassignment_data(interval)%prev_PET, 5, &
+            reassignment_data(interval)%prev_PET, 1, &
+            RCONST_recv(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * NREACT, MPI_DOUBLE_PRECISION, &
+            reassignment_data(interval)%next_PET, 1, &
             Input_Opt%mpiComm, MPI_STATUS_IGNORE, RC)
-        CALL MPI_Recv( &
+
+        CALL MPI_Sendrecv( &
             I_send(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * 20, MPI_INTEGER, &
-            reassignment_data(interval)%prev_PET, 6, &
+            reassignment_data(interval)%prev_PET, 2, &
+            I_recv(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * 20, MPI_INTEGER, &
+            reassignment_data(interval)%next_PET, 2, &
             Input_Opt%mpiComm, MPI_STATUS_IGNORE, RC)
-        CALL MPI_Recv( &
+
+        CALL MPI_Sendrecv( &
             R_send(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * 20, MPI_DOUBLE_PRECISION, &
-            reassignment_data(interval)%prev_PET, 7, &
+            reassignment_data(interval)%prev_PET, 3, &
+            R_recv(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * 20, MPI_DOUBLE_PRECISION, &
+            reassignment_data(interval)%next_PET, 3, &
             Input_Opt%mpiComm, MPI_STATUS_IGNORE, RC)
 #ifdef HIRES_TIMER
         TimerEnd = rdtsc()
         ! Write both times to timer log file
-        WRITE(unit_number, *) Interval, 'ReverseRecv', TimerStart, TimerEnd
+        WRITE(unit_number, *) Interval, 'ReverseMPI', TimerStart, TimerEnd
         
         TimerStart = rdtsc()
 #endif

--- a/GeosCore/fullchem_mod.F90
+++ b/GeosCore/fullchem_mod.F90
@@ -1153,34 +1153,42 @@ CONTAINS
         
         TimerStart = rdtsc()
 #endif
-        ! Pass the actual data
-        CALL MPI_Sendrecv( &
-            C_recv(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * NSPEC, MPI_DOUBLE_PRECISION, &
-            reassignment_data(interval)%next_PET, 4, &
-            C_send(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * NSPEC, MPI_DOUBLE_PRECISION, &
-            reassignment_data(interval)%prev_PET, 4, &
-            Input_Opt%mpiComm, MPI_STATUS_IGNORE, RC)
+      ! Pass the actual data
+      CALL MPI_Isend( &
+          C_recv(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * NSPEC, MPI_DOUBLE_PRECISION, &
+          reassignment_data(interval)%next_PET, 4, &
+          Input_Opt%mpiComm, request, RC)
+      CALL MPI_Recv( &
+          C_send(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * NSPEC, MPI_DOUBLE_PRECISION, &
+          reassignment_data(interval)%prev_PET, 4, &
+          Input_Opt%mpiComm, MPI_STATUS_IGNORE, RC)
 
-        CALL MPI_Sendrecv( &
-            RCONST_recv(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * NREACT, MPI_DOUBLE_PRECISION, &
-            reassignment_data(interval)%next_PET, 5, &
-            RCONST_send(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * NREACT, MPI_DOUBLE_PRECISION, &
-            reassignment_data(interval)%prev_PET, 5, &
-            Input_Opt%mpiComm, MPI_STATUS_IGNORE, RC)
+      CALL MPI_Isend( &
+          RCONST_recv(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * NREACT, MPI_DOUBLE_PRECISION, &
+          reassignment_data(interval)%next_PET, 5, &
+          Input_Opt%mpiComm, request, RC)
+      CALL MPI_Recv( &
+          RCONST_send(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * NREACT, MPI_DOUBLE_PRECISION, &
+          reassignment_data(interval)%prev_PET, 5, &
+          Input_Opt%mpiComm, MPI_STATUS_IGNORE, RC)
 
-        CALL MPI_Sendrecv( &
-            I_recv(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * 20, MPI_INTEGER, &
-            reassignment_data(interval)%next_PET, 6, &
-            I_send(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * 20, MPI_INTEGER, &
-            reassignment_data(interval)%prev_PET, 6, &
-            Input_Opt%mpiComm, MPI_STATUS_IGNORE, RC)
+      CALL MPI_Isend( &
+          I_recv(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * 20, MPI_INTEGER, &
+          reassignment_data(interval)%next_PET, 6, &
+          Input_Opt%mpiComm, request, RC)
+      CALL MPI_Recv( &
+          I_send(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * 20, MPI_INTEGER, &
+          reassignment_data(interval)%prev_PET, 6, &
+          Input_Opt%mpiComm, MPI_STATUS_IGNORE, RC)
 
-        CALL MPI_Sendrecv( &
-            R_recv(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * 20, MPI_DOUBLE_PRECISION, &
-            reassignment_data(interval)%next_PET, 7, &
-            R_send(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * 20, MPI_DOUBLE_PRECISION, &
-            reassignment_data(interval)%prev_PET, 7, &
-            Input_Opt%mpiComm, MPI_STATUS_IGNORE, RC)
+      CALL MPI_Isend( &
+          R_recv(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * 20, MPI_DOUBLE_PRECISION, &
+          reassignment_data(interval)%next_PET, 7, &
+          Input_Opt%mpiComm, request, RC)
+      CALL MPI_Recv( &
+          R_send(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * 20, MPI_DOUBLE_PRECISION, &
+          reassignment_data(interval)%prev_PET, 7, &
+          Input_Opt%mpiComm, MPI_STATUS_IGNORE, RC)
 #ifdef HIRES_TIMER
         TimerEnd = rdtsc()
         ! Write both times to timer log file
@@ -1439,34 +1447,42 @@ CONTAINS
 
         TimerStart = rdtsc()
 #endif
-        ! Pass the actual data
-        CALL MPI_Sendrecv( &
-            C_send(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * NSPEC, MPI_DOUBLE_PRECISION, &
-            reassignment_data(interval)%prev_PET, 0, &
-            C_recv(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * NSPEC, MPI_DOUBLE_PRECISION, &
-            reassignment_data(interval)%next_PET, 0, &
-            Input_Opt%mpiComm, MPI_STATUS_IGNORE, RC)
+      ! Pass the actual data
+      CALL MPI_Isend( &
+          C_send(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * NSPEC, MPI_DOUBLE_PRECISION, &
+          reassignment_data(interval)%prev_PET, 0, &
+          Input_Opt%mpiComm, request, RC)
+      CALL MPI_Recv( &
+          C_recv(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * NSPEC, MPI_DOUBLE_PRECISION, &
+          reassignment_data(interval)%next_PET, 0, &
+          Input_Opt%mpiComm, MPI_STATUS_IGNORE, RC)
 
-        CALL MPI_Sendrecv( &
-            RCONST_send(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * NREACT, MPI_DOUBLE_PRECISION, &
-            reassignment_data(interval)%prev_PET, 1, &
-            RCONST_recv(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * NREACT, MPI_DOUBLE_PRECISION, &
-            reassignment_data(interval)%next_PET, 1, &
-            Input_Opt%mpiComm, MPI_STATUS_IGNORE, RC)
+      CALL MPI_Isend( &
+          RCONST_send(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * NREACT, MPI_DOUBLE_PRECISION, &
+          reassignment_data(interval)%prev_PET, 1, &
+          Input_Opt%mpiComm, request, RC)
+      CALL MPI_Recv( &
+          RCONST_recv(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * NREACT, MPI_DOUBLE_PRECISION, &
+          reassignment_data(interval)%next_PET, 1, &
+          Input_Opt%mpiComm, MPI_STATUS_IGNORE, RC)
 
-        CALL MPI_Sendrecv( &
-            I_send(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * 20, MPI_INTEGER, &
-            reassignment_data(interval)%prev_PET, 2, &
-            I_recv(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * 20, MPI_INTEGER, &
-            reassignment_data(interval)%next_PET, 2, &
-            Input_Opt%mpiComm, MPI_STATUS_IGNORE, RC)
+      CALL MPI_Isend( &
+          I_send(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * 20, MPI_INTEGER, &
+          reassignment_data(interval)%prev_PET, 2, &
+          Input_Opt%mpiComm, request, RC)
+      CALL MPI_Recv( &
+          I_recv(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * 20, MPI_INTEGER, &
+          reassignment_data(interval)%next_PET, 2, &
+          Input_Opt%mpiComm, MPI_STATUS_IGNORE, RC)
 
-        CALL MPI_Sendrecv( &
-            R_send(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * 20, MPI_DOUBLE_PRECISION, &
-            reassignment_data(interval)%prev_PET, 3, &
-            R_recv(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * 20, MPI_DOUBLE_PRECISION, &
-            reassignment_data(interval)%next_PET, 3, &
-            Input_Opt%mpiComm, MPI_STATUS_IGNORE, RC)
+      CALL MPI_Isend( &
+          R_send(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * 20, MPI_DOUBLE_PRECISION, &
+          reassignment_data(interval)%prev_PET, 3, &
+          Input_Opt%mpiComm, request, RC)
+      CALL MPI_Recv( &
+          R_recv(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * 20, MPI_DOUBLE_PRECISION, &
+          reassignment_data(interval)%next_PET, 3, &
+          Input_Opt%mpiComm, MPI_STATUS_IGNORE, RC)
 #ifdef HIRES_TIMER
         TimerEnd = rdtsc()
         ! Write both times to timer log file

--- a/GeosCore/fullchem_mod.F90
+++ b/GeosCore/fullchem_mod.F90
@@ -1149,42 +1149,54 @@ CONTAINS
 #ifdef HIRES_TIMER
         TimerEnd = rdtsc()
         ! Write both times to timer log file
-        WRITE(unit_number, *) Interval, 'Forward pack', TimerStart, TimerEnd
+        WRITE(unit_number, *) Interval, 'ForwardPacking', TimerStart, TimerEnd
         
         TimerStart = rdtsc()
 #endif
-        ! Pass the actual data
-        CALL MPI_Sendrecv( &
+        ! Pass the actual data using non-blocking sends and blocking receives
+        CALL MPI_Isend( &
             C_send(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * NSPEC, MPI_DOUBLE_PRECISION, &
-            reassignment_data(interval)%prev_PET, 0, &
-            C_recv(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * NSPEC, MPI_DOUBLE_PRECISION, &
             reassignment_data(interval)%next_PET, 0, &
-            Input_Opt%mpiComm, MPI_STATUS_IGNORE, RC)
-
-        CALL MPI_Sendrecv( &
+            Input_Opt%mpiComm, request, RC)
+        CALL MPI_Isend( &
             RCONST_send(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * NREACT, MPI_DOUBLE_PRECISION, &
-            reassignment_data(interval)%prev_PET, 1, &
-            RCONST_recv(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * NREACT, MPI_DOUBLE_PRECISION, &
             reassignment_data(interval)%next_PET, 1, &
-            Input_Opt%mpiComm, MPI_STATUS_IGNORE, RC)
-
-        CALL MPI_Sendrecv( &
+            Input_Opt%mpiComm, request, RC)
+        CALL MPI_Isend( &
             I_send(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * 20, MPI_INTEGER, &
-            reassignment_data(interval)%prev_PET, 2, &
-            I_recv(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * 20, MPI_INTEGER, &
             reassignment_data(interval)%next_PET, 2, &
-            Input_Opt%mpiComm, MPI_STATUS_IGNORE, RC)
-
-        CALL MPI_Sendrecv( &
+            Input_Opt%mpiComm, request, RC)
+        CALL MPI_Isend( &
             R_send(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * 20, MPI_DOUBLE_PRECISION, &
-            reassignment_data(interval)%prev_PET, 3, &
-            R_recv(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * 20, MPI_DOUBLE_PRECISION, &
             reassignment_data(interval)%next_PET, 3, &
+            Input_Opt%mpiComm, request, RC)
+#ifdef HIRES_TIMER
+        TimerEnd = rdtsc()
+        ! Write both times to timer log file
+        WRITE(unit_number, *) Interval, 'ForwardISend', TimerStart, TimerEnd
+        
+        TimerStart = rdtsc()
+#endif
+        CALL MPI_Recv( &
+            C_recv(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * NSPEC, MPI_DOUBLE_PRECISION, &
+            reassignment_data(interval)%prev_PET, 0, &
+            Input_Opt%mpiComm, MPI_STATUS_IGNORE, RC)
+        CALL MPI_Recv( &
+            RCONST_recv(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * NREACT, MPI_DOUBLE_PRECISION, &
+            reassignment_data(interval)%prev_PET, 1, &
+            Input_Opt%mpiComm, MPI_STATUS_IGNORE, RC)
+        CALL MPI_Recv( &
+            I_recv(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * 20, MPI_INTEGER, &
+            reassignment_data(interval)%prev_PET, 2, &
+            Input_Opt%mpiComm, MPI_STATUS_IGNORE, RC)
+        CALL MPI_Recv( &
+            R_recv(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * 20, MPI_DOUBLE_PRECISION, &
+            reassignment_data(interval)%prev_PET, 3, &
             Input_Opt%mpiComm, MPI_STATUS_IGNORE, RC)
 #ifdef HIRES_TIMER
         TimerEnd = rdtsc()
         ! Write both times to timer log file
-        WRITE(unit_number, *) Interval, 'Forward MPI Sendrecv', TimerStart, TimerEnd
+        WRITE(unit_number, *) Interval, 'ForwardRecv', TimerStart, TimerEnd
         
         TimerStart = rdtsc()
 #endif
@@ -1201,11 +1213,14 @@ CONTAINS
 #ifdef HIRES_TIMER
         TimerEnd = rdtsc()
         ! Write both times to timer log file
-        WRITE(unit_number, *) Interval, 'Forward unpack', TimerStart, TimerEnd
-        
-        TimerStart = rdtsc()
+        WRITE(unit_number, *) Interval, 'ForwardUnpacking', TimerStart, TimerEnd
 #endif
     ENDIF
+#ifdef HIRES_TIMER
+        ! Always time the inbetween section
+        TimerStart = rdtsc()
+#endif
+
 #endif
     !$OMP PARALLEL DO                                                        &
     !$OMP DEFAULT( SHARED                                                   )&
@@ -1409,13 +1424,15 @@ CONTAINS
     ENDDO
 
 #ifdef MODEL_GCHPCTM
+#ifdef HIRES_TIMER
+    ! Always time the inbetween section
+    TimerEnd = rdtsc()
+    ! Write both times to timer log file
+    WRITE(unit_number, *) Interval, 'Inbetween', TimerStart, TimerEnd
+#endif
     ! Skip reverse load balancing if we are not moving any cells, i.e. target_PET = -1
     IF (reassignment_data(interval)%next_PET /= -1) THEN
 #ifdef HIRES_TIMER
-        TimerEnd = rdtsc()
-        ! Write both times to timer log file
-        WRITE(unit_number, *) Interval, 'Inbetween', TimerStart, TimerEnd
-       
         TimerStart = rdtsc()
 #endif
         ! Gather the columns to be swapped to the *_recv arrays
@@ -1430,42 +1447,54 @@ CONTAINS
 #ifdef HIRES_TIMER
         TimerEnd = rdtsc()
         ! Write both times to timer log file
-        WRITE(unit_number, *) Interval, 'Reverse pack', TimerStart, TimerEnd
+        WRITE(unit_number, *) Interval, 'ReversePacking', TimerStart, TimerEnd
 
         TimerStart = rdtsc()
 #endif
-        ! Pass the actual data
-        CALL MPI_Sendrecv( &
+        ! Pass the actual data using non-blocking sends and blocking receives
+        CALL MPI_Isend( &
             C_recv(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * NSPEC, MPI_DOUBLE_PRECISION, &
             reassignment_data(interval)%next_PET, 4, &
+            Input_Opt%mpiComm, request, RC)
+        CALL MPI_Isend( &
+            RCONST_recv(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * NREACT, MPI_DOUBLE_PRECISION, &
+            reassignment_data(interval)%next_PET, 5, &
+            Input_Opt%mpiComm, request, RC)
+        CALL MPI_Isend( &
+            I_recv(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * 20, MPI_INTEGER, &
+            reassignment_data(interval)%next_PET, 6, &
+            Input_Opt%mpiComm, request, RC)
+        CALL MPI_Isend( &
+            R_recv(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * 20, MPI_DOUBLE_PRECISION, &
+            reassignment_data(interval)%next_PET, 7, &
+            Input_Opt%mpiComm, request, RC)
+#ifdef HIRES_TIMER
+        TimerEnd = rdtsc()
+        ! Write both times to timer log file
+        WRITE(unit_number, *) Interval, 'ReverseIsend', TimerStart, TimerEnd
+        
+        TimerStart = rdtsc()
+#endif
+        CALL MPI_Recv( &
             C_send(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * NSPEC, MPI_DOUBLE_PRECISION, &
             reassignment_data(interval)%prev_PET, 4, &
             Input_Opt%mpiComm, MPI_STATUS_IGNORE, RC)
-
-        CALL MPI_Sendrecv( &
-            RCONST_recv(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * NREACT, MPI_DOUBLE_PRECISION, &
-            reassignment_data(interval)%next_PET, 5, &
+        CALL MPI_Recv( &
             RCONST_send(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * NREACT, MPI_DOUBLE_PRECISION, &
             reassignment_data(interval)%prev_PET, 5, &
             Input_Opt%mpiComm, MPI_STATUS_IGNORE, RC)
-
-        CALL MPI_Sendrecv( &
-            I_recv(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * 20, MPI_INTEGER, &
-            reassignment_data(interval)%next_PET, 6, &
+        CALL MPI_Recv( &
             I_send(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * 20, MPI_INTEGER, &
             reassignment_data(interval)%prev_PET, 6, &
             Input_Opt%mpiComm, MPI_STATUS_IGNORE, RC)
-
-        CALL MPI_Sendrecv( &
-            R_recv(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * 20, MPI_DOUBLE_PRECISION, &
-            reassignment_data(interval)%next_PET, 7, &
+        CALL MPI_Recv( &
             R_send(1,1), State_Grid%NZ * reassignment_data(interval)%NCELL_moving * 20, MPI_DOUBLE_PRECISION, &
             reassignment_data(interval)%prev_PET, 7, &
             Input_Opt%mpiComm, MPI_STATUS_IGNORE, RC)
 #ifdef HIRES_TIMER
         TimerEnd = rdtsc()
         ! Write both times to timer log file
-        WRITE(unit_number, *) Interval, 'Reverse MPI Sendrecv', TimerStart, TimerEnd
+        WRITE(unit_number, *) Interval, 'ReverseRecv', TimerStart, TimerEnd
         
         TimerStart = rdtsc()
 #endif
@@ -1481,7 +1510,7 @@ CONTAINS
 #ifdef HIRES_TIMER
         TimerEnd = rdtsc()
         ! Write both times to timer log file
-        WRITE(unit_number, *) Interval, 'Reverse Unpack', TimerStart, TimerEnd
+        WRITE(unit_number, *) Interval, 'ReverseUnpacking', TimerStart, TimerEnd
 #endif
     ENDIF
 #endif


### PR DESCRIPTION
- Splits MPI_SendRecv into MPI_Isend and MPI_Recv.
- Rearranged MPI_Isend and MPI_Recv into groups.
- Fixed the send and recv target processor (they were the opposite of what they are supposed to be).